### PR TITLE
Feature: Disable Implicit Signup for oauth implementations

### DIFF
--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -67,8 +67,14 @@ export const callbackOAuth = createAuthEndpoint(
 				`${c.context.baseURL}/error?error=oauth_provider_not_found`,
 			);
 		}
-		const { codeVerifier, callbackURL, link, errorURL, newUserURL } =
-			await parseState(c);
+		const {
+			codeVerifier,
+			callbackURL,
+			link,
+			errorURL,
+			newUserURL,
+			requestSignUp,
+		} = await parseState(c);
 
 		let tokens: OAuth2Tokens;
 		try {
@@ -149,6 +155,7 @@ export const callbackOAuth = createAuthEndpoint(
 				scope: tokens.scopes?.join(","),
 			},
 			callbackURL,
+			disableSignUp: provider.disableImplicitSignUp && !requestSignUp,
 		});
 		if (result.error) {
 			c.context.logger.error(result.error.split(" ").join("_"));

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -122,6 +122,19 @@ export const signInSocial = createAuthEndpoint(
 						"ID token from the provider to sign in the user with id token",
 				},
 			),
+			/**
+			 * Explicitly request sign-up
+			 *
+			 * Should be used to allow sign up when
+			 * disableImplicitSignUp for this provider is
+			 * true
+			 */
+			requestSignUp: z
+				.boolean({
+					description:
+						"Explicitly request sign-up. Useful when disableImplicitSignUp is true for this provider",
+				})
+				.optional(),
 		}),
 		metadata: {
 			openapi: {
@@ -228,6 +241,7 @@ export const signInSocial = createAuthEndpoint(
 					accountId: userInfo.user.id,
 					accessToken: c.body.idToken.accessToken,
 				},
+				disableSignUp: provider.disableImplicitSignUp && !c.body.requestSignUp,
 			});
 			if (data.error) {
 				throw new APIError("UNAUTHORIZED", {

--- a/packages/better-auth/src/init.ts
+++ b/packages/better-auth/src/init.ts
@@ -74,9 +74,14 @@ export const init = async (options: BetterAuthOptions) => {
 					`Social provider ${key} is missing clientId or clientSecret`,
 				);
 			}
-			return socialProviders[key as (typeof socialProviderList)[number]](
+			const provider = socialProviders[
+				key as (typeof socialProviderList)[number]
+			](
 				value as any, // TODO: fix this
 			);
+			(provider as OAuthProvider).disableImplicitSignUp =
+				value.disableImplicitSignUp;
+			return provider;
 		})
 		.filter((x) => x !== null);
 

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -10,10 +10,12 @@ export async function handleOAuthUserInfo(
 		userInfo,
 		account,
 		callbackURL,
+		disableSignUp,
 	}: {
 		userInfo: Omit<User, "createdAt" | "updatedAt">;
 		account: Omit<Account, "id" | "userId" | "createdAt" | "updatedAt">;
 		callbackURL?: string;
+		disableSignUp?: boolean;
 	},
 ) {
 	const dbUser = await c.context.internalAdapter
@@ -96,6 +98,13 @@ export async function handleOAuthUserInfo(
 			}
 		}
 	} else {
+		if (disableSignUp) {
+			return {
+				error: "signup disabled",
+				data: null,
+				isRegister: false,
+			};
+		}
 		try {
 			user = await c.context.internalAdapter
 				.createOAuthUser(

--- a/packages/better-auth/src/oauth2/state.ts
+++ b/packages/better-auth/src/oauth2/state.ts
@@ -32,6 +32,7 @@ export async function generateState(
 		 * This is the actual expiry time of the state
 		 */
 		expiresAt: Date.now() + 10 * 60 * 1000,
+		requestSignUp: c.body?.requestSignUp,
 	});
 	const expiresAt = new Date();
 	expiresAt.setMinutes(expiresAt.getMinutes() + 10);
@@ -78,6 +79,7 @@ export async function parseState(c: GenericEndpointContext) {
 					userId: z.string(),
 				})
 				.optional(),
+			requestSignUp: z.boolean().optional(),
 		})
 		.parse(JSON.parse(data.value));
 

--- a/packages/better-auth/src/oauth2/types.ts
+++ b/packages/better-auth/src/oauth2/types.ts
@@ -39,6 +39,7 @@ export interface OAuthProvider<
 	refreshAccessToken?: (refreshToken: string) => Promise<OAuth2Tokens>;
 	revokeToken?: (token: string) => Promise<void>;
 	verifyIdToken?: (token: string, nonce?: string) => Promise<boolean>;
+	disableImplicitSignUp?: boolean;
 }
 
 export type ProviderOptions<Profile extends Record<string, any> = any> = {
@@ -105,4 +106,9 @@ export type ProviderOptions<Profile extends Record<string, any> = any> = {
 				emailVerified?: boolean;
 				[key: string]: any;
 		  }>;
+	/**
+	 * Disable implicit sign up for new users. When set to true for the provider,
+	 * sign-in need to be calle dwith with requestSignUp as true to create new users.
+	 */
+	disableImplicitSignUp?: boolean;
 };

--- a/packages/better-auth/src/plugins/sso/index.ts
+++ b/packages/better-auth/src/plugins/sso/index.ts
@@ -61,6 +61,11 @@ interface SSOOptions {
 			provider: SSOProvider;
 		}) => Promise<"member" | "admin">;
 	};
+	/**
+	 * Disable implicit sign up for new users. When set to true for the provider,
+	 * sign-in need to be calle dwith with requestSignUp as true to create new users.
+	 */
+	disableImplicitSignUp?: boolean;
 }
 
 export const sso = (options?: SSOOptions) => {
@@ -252,6 +257,12 @@ export const sso = (options?: SSOOptions) => {
 									"The URL to redirect to after login if the user is new",
 							})
 							.optional(),
+						requestSignUp: z
+							.boolean({
+								description:
+									"Explicitly request sign-up. Useful when disableImplicitSignUp is true for this provider",
+							})
+							.optional(),
 					}),
 					metadata: {
 						openapi: {
@@ -407,7 +418,8 @@ export const sso = (options?: SSOOptions) => {
 							`${ctx.context.baseURL}/error?error=invalid_state`,
 						);
 					}
-					const { callbackURL, errorURL, newUserURL } = stateData;
+					const { callbackURL, errorURL, newUserURL, requestSignUp } =
+						stateData;
 					if (!code || error) {
 						throw ctx.redirect(
 							`${
@@ -620,6 +632,7 @@ export const sso = (options?: SSOOptions) => {
 							refreshTokenExpiresAt: tokenResponse.refreshTokenExpiresAt,
 							scope: tokenResponse.scopes?.join(","),
 						},
+						disableSignUp: options?.disableImplicitSignUp && !requestSignUp,
 					});
 					if (linked.error) {
 						throw ctx.redirect(

--- a/packages/better-auth/src/plugins/sso/sso.test.ts
+++ b/packages/better-auth/src/plugins/sso/sso.test.ts
@@ -174,6 +174,151 @@ describe("SSO", async () => {
 	});
 });
 
+describe("SSO disable implicit sign in", async () => {
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		plugins: [sso({ disableImplicitSignUp: true }), organization()],
+	});
+
+	beforeAll(async () => {
+		await server.issuer.keys.generate("RS256");
+		server.issuer.on;
+		await server.start(8080, "localhost");
+		console.log("Issuer URL:", server.issuer.url); // -> http://localhost:8080
+	});
+
+	afterAll(async () => {
+		await server.stop();
+	});
+
+	server.service.on("beforeUserinfo", (userInfoResponse, req) => {
+		userInfoResponse.body = {
+			email: "oauth2@test.com",
+			name: "OAuth2 Test",
+			sub: "oauth2",
+			picture: "https://test.com/picture.png",
+			email_verified: true,
+		};
+		userInfoResponse.statusCode = 200;
+	});
+
+	server.service.on("beforeTokenSigning", (token, req) => {
+		token.payload.email = "sso-user@localhost:8000.com";
+		token.payload.email_verified = true;
+		token.payload.name = "Test User";
+		token.payload.picture = "https://test.com/picture.png";
+	});
+
+	async function simulateOAuthFlow(
+		authUrl: string,
+		headers: Headers,
+		fetchImpl?: (...args: any) => any,
+	) {
+		let location: string | null = null;
+		await betterFetch(authUrl, {
+			method: "GET",
+			redirect: "manual",
+			onError(context) {
+				location = context.response.headers.get("location");
+			},
+		});
+
+		if (!location) throw new Error("No redirect location found");
+
+		let callbackURL = "";
+		await betterFetch(location, {
+			method: "GET",
+			customFetchImpl: fetchImpl || customFetchImpl,
+			headers,
+			onError(context) {
+				callbackURL = context.response.headers.get("location") || "";
+			},
+		});
+
+		return callbackURL;
+	}
+
+	it("should register a new SSO provider", async () => {
+		const { headers } = await signInWithTestUser();
+		const provider = await auth.api.createOIDCProvider({
+			body: {
+				issuer: server.issuer.url!,
+				domain: "localhost.com",
+				clientId: "test",
+				clientSecret: "test",
+				authorizationEndpoint: `${server.issuer.url}/authorize`,
+				tokenEndpoint: `${server.issuer.url}/token`,
+				jwksEndpoint: `${server.issuer.url}/jwks`,
+				mapping: {
+					id: "sub",
+					email: "email",
+					emailVerified: "email_verified",
+					name: "name",
+					image: "picture",
+				},
+				providerId: "test",
+			},
+			headers,
+		});
+		expect(provider).toMatchObject({
+			id: expect.any(String),
+			issuer: "http://localhost:8080",
+			oidcConfig: {
+				issuer: "http://localhost:8080",
+				clientId: "test",
+				clientSecret: "test",
+				authorizationEndpoint: "http://localhost:8080/authorize",
+				tokenEndpoint: "http://localhost:8080/token",
+				jwksEndpoint: "http://localhost:8080/jwks",
+				discoveryEndpoint:
+					"http://localhost:8080/.well-known/openid-configuration",
+				mapping: {
+					id: "sub",
+					email: "email",
+					emailVerified: "email_verified",
+					name: "name",
+					image: "picture",
+				},
+			},
+			userId: expect.any(String),
+		});
+	});
+
+	it("should not create user with SSO provider when sign ups are disabled", async () => {
+		const res = await auth.api.signInSSO({
+			body: {
+				email: "my-email@localhost.com",
+				callbackURL: "/dashboard",
+			},
+		});
+		expect(res.url).toContain("http://localhost:8080/authorize");
+		expect(res.url).toContain(
+			"redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fapi%2Fauth%2Fsso%2Fcallback%2Ftest",
+		);
+		const headers = new Headers();
+		const callbackURL = await simulateOAuthFlow(res.url, headers);
+		expect(callbackURL).toContain(
+			"/api/auth/error/error?error=signup disabled",
+		);
+	});
+
+	it("should create user with SSO provider when sign ups are disabled but sign up is requested", async () => {
+		const res = await auth.api.signInSSO({
+			body: {
+				email: "my-email@localhost.com",
+				callbackURL: "/dashboard",
+				requestSignUp: true,
+			},
+		});
+		expect(res.url).toContain("http://localhost:8080/authorize");
+		expect(res.url).toContain(
+			"redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fapi%2Fauth%2Fsso%2Fcallback%2Ftest",
+		);
+		const headers = new Headers();
+		const callbackURL = await simulateOAuthFlow(res.url, headers);
+		expect(callbackURL).toContain("/dashboard");
+	});
+});
+
 describe("provisioning", async (ctx) => {
 	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
 		plugins: [sso(), organization()],


### PR DESCRIPTION
- Added disableImplicitSignup option to social providers, generic oauth privders and sso plugin
- With disableImplicitSignup as true, signing in with a new email will fail
- Client may use requestSignUp as true to indicate they're explicitly asking for a sign up
- Added unit tests for social providers, generic oauth and sso plugin